### PR TITLE
fix: cloudflare pagesのビルドがコケるので互換性の設定をした

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,1 @@
+compatibility_flags = ["nodejs_compat"]


### PR DESCRIPTION
cloudflare pagesのビルドが現状だとコケるので互換性の設定をした
https://developers.cloudflare.com/workers/configuration/compatibility-dates/#compatibility-flags