### PR TITLE
SWRでサブリクエストを送る際にundefinedの場合はリクエストを送信しない

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2091,6 +2091,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/app/forms/page.tsx
+++ b/src/app/forms/page.tsx
@@ -25,14 +25,14 @@ const DashboardPage: NextPage = () => {
     data: formsRes,
     error: formsResError,
     isLoading: formsResIsLoading,
-  } = useSWR(() => `/forms?project_id=` + project?.id);
+  } = useSWR(() => project && `/forms?project_id=` + project?.id);
   const forms = formsRes ? assignType("/forms", formsRes) : undefined;
 
   const {
     data: answersRes,
     error: answersResError,
     isLoading: answersResIsLoading,
-  } = useSWR(() => `/form-answers?project_id=` + project?.id);
+  } = useSWR(() => project && `/form-answers?project_id=` + project?.id);
   const answers = answersRes ? assignType("/form-answers", answersRes) : undefined;
 
   const hiddenFormIds = useAtomValue(hiddenFormIdsAtom);


### PR DESCRIPTION
`project/invalid-uuid` を防ぐため