### PR TITLE
企画者画面で新規作成ボタンを非表示に修正

### DIFF
--- a/src/common_components/news/NewsView.tsx
+++ b/src/common_components/news/NewsView.tsx
@@ -135,6 +135,7 @@ export const NewsView: FC<Props> = ({ isCommittee, isDashboard = false }) => {
           </>
         )}
         {!isLoading_user &&
+          isCommittee &&
           ["committee_drafter", "committee_editor", "committee_operator", "administrator"].includes(me.role) && (
             <>
               <Button


### PR DESCRIPTION
プルリク名の通りです
無断で修正したのはすみません