### PR TITLE
CD(prod)のタグ打ちをなくした

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -1,13 +1,17 @@
 name: CD(Production)
 run-name: CD(Production) - ${{ github.event_name }}
 
-on:
-  push:
-  workflow_dispatch:
-
 env:
   PROJECT_NAME: ${{ vars.PROD_CLOUDFLARE_PROJECT_NAME }}
   PRODUCTION_BRANCH: main
+
+on:
+  pull_request:
+    branches:
+      - ${{ env.PRODUCTION_BRANCH }}
+    types:
+      - closed
+  workflow_dispatch:
 
 jobs:
   build_and_deploy:

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -3,8 +3,6 @@ run-name: CD(Production) - ${{ github.event_name }}
 
 on:
   push:
-    tags:
-      - v*
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
誰も使わないので
毎回workflow dispatchするのが面倒なため