### PR TITLE
fix:場所未定の表示を「未定」に統一

### DIFF
--- a/src/app/committee/projects/ProjectsList.tsx
+++ b/src/app/committee/projects/ProjectsList.tsx
@@ -57,7 +57,7 @@ const ProjectRow: React.FC<{ data: components["schemas"]["ProjectSummary"] }> = 
           fontWeight: "bold",
         })}>
         <Image src={LocationIcon} alt="" />
-        {data.location_id ?? "未定"}
+        {!data.location_id ? "未定" : data.location_id}
       </div>
       <div className={vstack({ alignItems: "end" })}>
         <div

--- a/src/common_components/project/ProjectView.tsx
+++ b/src/common_components/project/ProjectView.tsx
@@ -210,7 +210,7 @@ export const ProjectTableView: React.FC<{
           {<ProjectAttributesBadge attributes={projectData.attributes} />}
         </TableRow>
         <TableRow label="企画実施場所番号" formId="attributes">
-          {projectData?.location_id ?? "未定"}
+          {!projectData?.location_id ? "未定" : projectData?.location_id}
         </TableRow>
       </div>
       {isEditMode && (


### PR DESCRIPTION
「??」は前の部分がnullまたはundefinedの時に後ろの値を返すため、空文字列の時はそのまま表示されてしまっていました。
undefined,null,空文字列は真理値を見るとすべてfalseを返すので、そちらで判断するように変更しました。